### PR TITLE
feat(react-uploader): bump @uploadcare/blocks from 0.39.1 to 0.46.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2310,13 +2310,14 @@
       }
     },
     "node_modules/@uploadcare/blocks": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@uploadcare/blocks/-/blocks-0.39.1.tgz",
-      "integrity": "sha512-WdjlUYCeuaju83ImELIVsrLlZpi6IIWidnh+/LfIiX8ht1KJGH9DgK7ekoUyWxjE8ggwnPNIz4xnMKmIGlow7w==",
+      "version": "0.46.3",
+      "resolved": "https://registry.npmjs.org/@uploadcare/blocks/-/blocks-0.46.3.tgz",
+      "integrity": "sha512-n4EgPApqvxpcIvJ8K2HjkpdU+umIOD0XBX/jx4R0NFAJ8X2DXqIZxTkz6KIjDDR+yxjwTqrc7v2Jh6JIHgO4qQ==",
       "dependencies": {
         "@symbiotejs/symbiote": "^1.11.7",
         "@uploadcare/image-shrink": "^6.14.1",
-        "@uploadcare/upload-client": "^6.14.1"
+        "@uploadcare/upload-client": "^6.14.1",
+        "keyux": "^0.7.1"
       }
     },
     "node_modules/@uploadcare/image-shrink": {
@@ -5467,6 +5468,20 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/keyux": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/keyux/-/keyux-0.7.2.tgz",
+      "integrity": "sha512-Z8ULf9BhSx1hI2rKG2uNjcvMgQmza97ZW2w43phS5VaT4wiTka7tOL4i/GJSc79k65tbvpoTVNCZwam0pqoH6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/kind-of": {
@@ -10817,9 +10832,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10940,7 +10955,7 @@
       "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
-        "@uploadcare/blocks": "^0.39.1",
+        "@uploadcare/blocks": "^0.46.3",
         "@uploadcare/react-adapter": "^0.3.0"
       },
       "peerDependencies": {

--- a/packages/react-uploader/package.json
+++ b/packages/react-uploader/package.json
@@ -27,7 +27,7 @@
     "@types/react": "17 || 18"
   },
   "dependencies": {
-    "@uploadcare/blocks": "^0.39.1",
+    "@uploadcare/blocks": "^0.46.3",
     "@uploadcare/react-adapter": "^0.3.0"
   },
   "repository": {


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
